### PR TITLE
chore: make the lint gate green and actually run it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
     types: ['opened', 'synchronize']
-    branches: [main]
+    branches: [master, main]
 
 jobs:
   automated-test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,8 @@ jobs:
       - name: check types
         run: pnpm typecheck
 
-      # - name: lint
-      #   run: pnpm lint
+      - name: lint
+        run: pnpm lint
 
       - name: test
         run: pnpm test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 echo "🔍 Running pre-commit checks..."
 
 # Get list of staged files

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -9,7 +9,7 @@ export { davRequest, propfind, createObject, updateObject, deleteObject } from '
 export { collectionQuery, supportedReportSet, isCollectionDirty, syncCollection, smartCollectionSync, } from './collection';
 export { calendarQuery, calendarMultiGet, makeCalendar, fetchCalendars, fetchCalendarUserAddresses, fetchCalendarObjects, createCalendarObject, updateCalendarObject, deleteCalendarObject, syncCalendars, freeBusyQuery, } from './calendar';
 export { addressBookQuery, addressBookMultiGet, fetchAddressBooks, fetchVCards, createVCard, updateVCard, deleteVCard, makeAddressBook, } from './addressBook';
-export { todoQuery, todoMultiGet, fetchTodos, createTodo, updateTodo, deleteTodo, } from './todo';
+export { todoQuery, todoMultiGet, fetchTodos, createTodo, updateTodo, deleteTodo } from './todo';
 export { getBasicAuthHeaders, getBearerAuthHeaders, getOauthHeaders, fetchOauthTokens, refreshAccessToken, } from './util/authHelpers';
 export { urlContains, urlEquals, getDAVAttribute, cleanupFalsy } from './util/requestHelpers';
 export { DAVNamespace, DAVAttributeMap, DAVNamespaceShort } from './consts';

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsdav",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "WebDAV, CALDAV, and CARDDAV client for Nodejs and the Browser",
   "keywords": [
     "dav",

--- a/dist/tsdav.cjs
+++ b/dist/tsdav.cjs
@@ -823,10 +823,7 @@ const makeAddressBook = async (params) => {
             body: props
                 ? {
                     mkcol: {
-                        _attributes: getDAVAttribute([
-                            exports.DAVNamespace.DAV,
-                            exports.DAVNamespace.CARDDAV,
-                        ]),
+                        _attributes: getDAVAttribute([exports.DAVNamespace.DAV, exports.DAVNamespace.CARDDAV]),
                         set: {
                             prop: props,
                         },

--- a/dist/tsdav.cjs.js
+++ b/dist/tsdav.cjs.js
@@ -823,10 +823,7 @@ const makeAddressBook = async (params) => {
             body: props
                 ? {
                     mkcol: {
-                        _attributes: getDAVAttribute([
-                            exports.DAVNamespace.DAV,
-                            exports.DAVNamespace.CARDDAV,
-                        ]),
+                        _attributes: getDAVAttribute([exports.DAVNamespace.DAV, exports.DAVNamespace.CARDDAV]),
                         set: {
                             prop: props,
                         },

--- a/dist/tsdav.esm.js
+++ b/dist/tsdav.esm.js
@@ -819,10 +819,7 @@ const makeAddressBook = async (params) => {
             body: props
                 ? {
                     mkcol: {
-                        _attributes: getDAVAttribute([
-                            DAVNamespace.DAV,
-                            DAVNamespace.CARDDAV,
-                        ]),
+                        _attributes: getDAVAttribute([DAVNamespace.DAV, DAVNamespace.CARDDAV]),
                         set: {
                             prop: props,
                         },

--- a/dist/tsdav.js
+++ b/dist/tsdav.js
@@ -10013,10 +10013,7 @@ const makeAddressBook = async (params) => {
             body: props
                 ? {
                     mkcol: {
-                        _attributes: getDAVAttribute([
-                            DAVNamespace.DAV,
-                            DAVNamespace.CARDDAV,
-                        ]),
+                        _attributes: getDAVAttribute([DAVNamespace.DAV, DAVNamespace.CARDDAV]),
                         set: {
                             prop: props,
                         },

--- a/dist/tsdav.mjs
+++ b/dist/tsdav.mjs
@@ -819,10 +819,7 @@ const makeAddressBook = async (params) => {
             body: props
                 ? {
                     mkcol: {
-                        _attributes: getDAVAttribute([
-                            DAVNamespace.DAV,
-                            DAVNamespace.CARDDAV,
-                        ]),
+                        _attributes: getDAVAttribute([DAVNamespace.DAV, DAVNamespace.CARDDAV]),
                         set: {
                             prop: props,
                         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsdav",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "WebDAV, CALDAV, and CARDDAV client for Nodejs and the Browser",
   "keywords": [
     "dav",

--- a/src/addressBook.ts
+++ b/src/addressBook.ts
@@ -352,10 +352,7 @@ export const makeAddressBook = async (params: {
       body: props
         ? {
             mkcol: {
-              _attributes: getDAVAttribute([
-                DAVNamespace.DAV,
-                DAVNamespace.CARDDAV,
-              ]),
+              _attributes: getDAVAttribute([DAVNamespace.DAV, DAVNamespace.CARDDAV]),
               set: {
                 prop: props,
               },

--- a/src/client.ts
+++ b/src/client.ts
@@ -706,9 +706,7 @@ export class DAVClient {
     })(params[0]);
   }
 
-  async makeAddressBook(
-    ...params: Parameters<typeof rawMakeAddressBook>
-  ): Promise<DAVResponse[]> {
+  async makeAddressBook(...params: Parameters<typeof rawMakeAddressBook>): Promise<DAVResponse[]> {
     return defaultParam(rawMakeAddressBook, {
       headers: this.authHeaders,
       fetchOptions: this.fetchOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,14 +60,7 @@ export {
   makeAddressBook,
 } from './addressBook';
 
-export {
-  todoQuery,
-  todoMultiGet,
-  fetchTodos,
-  createTodo,
-  updateTodo,
-  deleteTodo,
-} from './todo';
+export { todoQuery, todoMultiGet, fetchTodos, createTodo, updateTodo, deleteTodo } from './todo';
 
 export {
   getBasicAuthHeaders,

--- a/src/todo.ts
+++ b/src/todo.ts
@@ -202,10 +202,7 @@ export const fetchTodos = async (params: {
       throw new Error('cannot fetchTodos for undefined calendar');
     }
     throw new Error(
-      `calendar must have ${findMissingFieldNames(
-        calendar,
-        requiredFields,
-      )} before fetchTodos`,
+      `calendar must have ${findMissingFieldNames(calendar, requiredFields)} before fetchTodos`,
     );
   }
 


### PR DESCRIPTION
> **Stacked on #32** — base is `fix/todo-fetch-override`, not `master`. See "Why stacked" below; GitHub will retarget this to `master` automatically once #32 merges. Review #32 first.

The three loose ends from #30/#31, and the reason they went unnoticed for so long.

## The through-line

`pnpm lint` has been red on master. Nothing caught it, because **the lint gate never ran**:

- `ci.yml` — the workflow that runs `typecheck`, `lint` and `test` — triggers only on pull requests to `main`. The default branch is `master` and no `main` branch exists, so it has never run on any PR. That is also why the `makeAddressBook` typecheck error from #31 sat on master unnoticed.
- `release.yml` had its `lint` step commented out.

So the only workflow that actually ran was `quality-checks.yml`, which does not lint.

## Changes

| Commit | |
|---|---|
| `style: apply prettier to the last lint holdouts` | `pnpm lint --fix`. Whitespace only across 4 files. |
| `chore(hooks): drop deprecated husky v8 preamble` | Removes the shebang + `_/husky.sh` source. |
| `ci: run CI on pull requests to master` | `branches: [main]` → `[master, main]`, matching quality-checks.yml. |
| `ci: re-enable lint in the release workflow` | Uncomments the step. |

`pnpm lint` now reports 0 errors, and two workflows will actually enforce it.

The husky change is verified rather than assumed: the three commits after it were made with the preamble removed, and the hook still ran every check — signature scan, version check, dist rebuild — with the DEPRECATED warning gone.

The prettier pass is whitespace only, but the non-minified bundles pick up the reformatting, so `dist/` is rebuilt and the patch version bumped. The dist diff is generated; the CI gate verifies it.

## Why stacked on #32

Basing this on `master` produces a genuine merge conflict with #32. Both branches rewrite the same lines of `client.ts`: prettier collapses the six long single-line `DAVClient` todo methods into multi-line form, and #32 rewrites those same lines into multi-line form *plus* a `fetch: this.fetchOverride` entry. Two different rewrites of the same region — git cannot auto-merge them. I confirmed this by building the branch both ways.

Stacking avoids it: `lint --fix` runs against the post-#32 tree, where 6 of the 10 errors are already gone as a side effect of that PR, leaving only the 4 genuinely-formatting ones. Merge #32 first and this applies cleanly. If you would rather have it off `master`, say so and I will re-cut it — that just means #32 rebases instead.

## Verification

```
$ pnpm lint      # 0 errors
$ pnpm typecheck # clean
$ pnpm test
Tests:       42 passed, 42 total
```

Workflow triggers after the change:

```
ci             -> pull_request: branches ['master', 'main']
release        -> release: types ['published']
quality-checks -> pull_request + push: branches ['master', 'main']
```

## Note

`ci.yml` will now run for real for the first time, on this PR and every future one. It runs `pnpm test` across Node 18/20/22/24 with mocked fetch. If it turns up something that has been failing invisibly on a Node version I have not exercised locally (I am on 22, `.nvmrc` says 24), that is the gate doing its job rather than a regression from this PR — tell me and I will fix it separately.

## CI status on this PR

This PR shows **0 checks**, and that is expected: `quality-checks.yml` triggers on `pull_request: branches: [master, main]`, so it does not fire for a PR targeting `fix/todo-fetch-override`. Once #32 merges and GitHub retargets this to `master`, the workflow will run.

Until then the gates were run locally against this exact tree: `pnpm lint` 0 errors, `pnpm typecheck` clean, 42/42 tests, and the dist gate (`pnpm build` then `git diff dist/`) reproduces the committed build.
